### PR TITLE
Fix CodeDeploy service validation

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -20,3 +20,7 @@ hooks:
     - location: scripts/stop_bot
       timeout: 300
       runas: root
+  ValidateService:
+    - location: scripts/validate_bot_running
+      timeout: 300
+      runas: root

--- a/scripts/validate_bot_running
+++ b/scripts/validate_bot_running
@@ -1,0 +1,3 @@
+#!/bin/bash
+sleep 1 # give service time to start
+sudo systemctl is-active --quiet invasion-bot.service


### PR DESCRIPTION
This resolves #3 by adding a CodeDeploy ValidateService hook referencing a new script that waits a moment before checking if the invasion-bot.service is running. 