### PR TITLE
Add announcement function

### DIFF
--- a/announcement_schedules.json.template
+++ b/announcement_schedules.json.template
@@ -1,0 +1,7 @@
+{
+    "city_name": {
+        "announcement_channel_id": 871635135065172849,
+        "announcement_hour": 18,
+        "announcement_minute": 30
+    }
+}

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -219,7 +219,7 @@ async def is_hour_in_future(hour) -> bool:
     logger.debug(f'Completed is_hour_in_future() with hour {hour_int}:{minute_int} and got result: {result}')
     return result
 
-def refresh_invasion_data(city:str = None) -> None:
+async def refresh_invasion_data(city:str = None) -> None:
     '''Gets invasion status from dynamodb for [city] or all cities if [city=None] (default)'''
     logger.debug(f'Attempting to refresh_invasion_data({city})')
     if city:
@@ -263,7 +263,7 @@ def refresh_invasion_data(city:str = None) -> None:
             logger.debug(f"Determined no invasion is happening tomorrow in {c_name}")
     logger.debug('Completed running refresh_invasion_data()')
 
-def refresh_siege_window(city:str = None) -> None:
+async def refresh_siege_window(city:str = None) -> None:
     '''Gets siege window data from dynamodb for [city] or all cities if [city=None] (default)'''
     logger.debug(f'Attempting to refresh_siege_window({city})')
     table_name = config['SIEGE_INFO_TABLE_NAME']
@@ -432,8 +432,8 @@ async def windows(ctx):
 async def info_gather():
     '''Executes referesh_invasion_data and refresh_siege_window every hour or on command'''
     logger.info('Attempting to run scheduled task info_gather()')
-    refresh_invasion_data()
-    refresh_siege_window()
+    await refresh_invasion_data()
+    await refresh_siege_window()
     logger.info('Completed running scheduled task info_gather()')
 
 bot.run(config['DISCORD_TOKEN'])

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -10,6 +10,7 @@
 # pylint: disable=C0206,C0301,R0912,R0915,W0703,W1203
 
 import datetime
+import json
 import logging
 import math
 import os
@@ -18,6 +19,8 @@ from logging.handlers import RotatingFileHandler
 
 import boto3
 import discord
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
 from botocore.exceptions import ClientError
 from discord.ext import tasks
 from discord_slash import SlashCommand
@@ -28,19 +31,11 @@ from dotenv import dotenv_values
 if 'LOGNAME' not in os.environ: # logname is env var on ec2, not on local dev
     DEV_MODE = True
     _FILE_PREFIX = ''
+    SCHEDULER_CONFIG_FILEPATH = None
 else:
     DEV_MODE = False
     _FILE_PREFIX = '/opt/invasion-bot/'
-
-# Load configuration
-try:
-    config = {
-        **dotenv_values(f'{_FILE_PREFIX}.env'),
-        **dotenv_values(f'{_FILE_PREFIX}.env.secret'),
-        **os.environ # override .env vars with os environment vars
-    }
-except Exception as e:
-    sys.exit(f'Failed to load configuration: {e}')
+    SCHEDULER_CONFIG_FILEPATH = f'{_FILE_PREFIX}announcement_schedules.json'
 
 CITY_INFO = {
     'Brightwood': {},
@@ -55,6 +50,33 @@ CITY_INFO = {
     'Windsward': {},
     "Weaver's Fen": {}
 }
+
+CITIES_WITH_ANNOUNCE_ENABLED = []
+TODAYS_CITIES_WITH_INVASIONS = []
+TOMORROWS_CITIES_WITH_INVASIONS= []
+
+# Load configuration
+try:
+    config = {
+        **dotenv_values(f'{_FILE_PREFIX}.env'),
+        **dotenv_values(f'{_FILE_PREFIX}.env.secret'),
+        **os.environ # override .env vars with os environment vars
+    }
+    if SCHEDULER_CONFIG_FILEPATH is not None:
+        with open(SCHEDULER_CONFIG_FILEPATH, encoding='utf-8') as f:
+            scheduling_config = json.load(f)
+        for sched_city in scheduling_config:
+            CITIES_WITH_ANNOUNCE_ENABLED.append(sched_city)
+            CITY_INFO[sched_city]['announcement_channel_id'] = int(scheduling_config[sched_city]['announcement_channel_id'])
+            CITY_INFO[sched_city]['announcement_hour'] = int(scheduling_config[sched_city]['announcement_hour'])
+            CITY_INFO[sched_city]['announcement_minute'] = int(scheduling_config[sched_city]['announcement_minute'])
+            assert len(str(CITY_INFO[sched_city]['announcement_channel_id'])) == 18
+            assert CITY_INFO[sched_city]['announcement_hour'] <= 24
+            assert CITY_INFO[sched_city]['announcement_hour'] > 0
+            assert CITY_INFO[sched_city]['announcement_minute'] < 60
+            assert CITY_INFO[sched_city]['announcement_minute'] >= 0
+except Exception as e:
+    sys.exit(f'Failed to load configuration: {e}')
 
 # Configure logging
 try:
@@ -91,10 +113,37 @@ except ClientError as e:
 else:
     logger.debug('Initialized Boto3 dynamodb session')
 
+@bot.event
+async def on_ready():
+    '''This function is activated when the bot reaches a 'ready' state.'''
+    logger.debug('Bot is ready')
+    if not DEV_MODE:
+        try:
+            scheduler = AsyncIOScheduler()
+            for city in CITIES_WITH_ANNOUNCE_ENABLED:
+                scheduler.add_job(
+                    send_city_invasion_announcement,
+                    trigger=CronTrigger(
+                        hour=str(CITY_INFO[city]['announcement_hour']),
+                        minute=str(CITY_INFO[city]['announcement_minute']),
+                        second="0"),
+                    args=[city]
+                )
+            scheduler.add_job(
+                refresh_invasion_data,
+                trigger=CronTrigger(hour="0", minute="0", second="0")
+            ) # daily task at midnight
+            scheduler.start()
+        except Exception as sched_exception:
+            logger.exception(f'Failed to start scheduler: {sched_exception}')
+        else:
+            logger.debug('Initialized scheduler and added channel-announce function')
+    info_gather.start()
+
 async def convert_time_str_to_min_sec(hour) -> int:
     '''Intakes a string with style 08:30 PM and returns 24-hour format time int: 20'''
     in_hour = int(hour.split(':')[0]) # split 08:30 PM style string to 08
-    in_minute = int(hour.split(':')[1].split(' ')[0]) # split 8:00 PM style string to 30
+    in_minute = int(hour.split(':')[1].split(' ')[0]) # split 8:30 PM style string to 30
     in_ampm = hour.split(' ')[1] # split 08:30 PM style string to PM
     if in_ampm == 'PM':
         in_hour += 12
@@ -102,39 +151,36 @@ async def convert_time_str_to_min_sec(hour) -> int:
 
 async def get_city_invasion_string(city, day=None) -> str:
     '''Returns a string detailing invasion status for a [city] on [day] or both today/tomorrow if [day=None](default)'''
-    # verify today's invasions are actually for today, otherwise refresh data
-    if CITY_INFO[city]['invasion_today_date'] != datetime.date.today().strftime('%Y-%m-%d'):
-        await refresh_invasion_data()
     siege_window_in_future = await is_hour_in_future(CITY_INFO[city]['siege_time'])
     if day is None: # both days
         # if invasion later and it is not siege time yet
-        if CITY_INFO[city]['invasion_today'] and siege_window_in_future:
+        if (city in TODAYS_CITIES_WITH_INVASIONS) and siege_window_in_future:
             duration_str = await get_time_til_hour(CITY_INFO[city]['siege_time'])
             response = f"{city} has an invasion later today in {duration_str} at {CITY_INFO[city]['siege_time']} EST"
         # if invasion happened earlier today
-        if CITY_INFO[city]['invasion_today'] and not siege_window_in_future:
+        if (city in TODAYS_CITIES_WITH_INVASIONS) and not siege_window_in_future:
             response = f"{city} had an invasion earlier today at {CITY_INFO[city]['siege_time']} EST"
         # if invasion is tomorrow
-        if CITY_INFO[city]['invasion_tomorrow']:
+        if city in TOMORROWS_CITIES_WITH_INVASIONS:
             response = f"{city} has an invasion tomorrow at {CITY_INFO[city]['siege_time']} EST"
         # if no invasions next two days
-        if not CITY_INFO[city]['invasion_today'] and not CITY_INFO[city]['invasion_tomorrow']:
+        if (city not in TODAYS_CITIES_WITH_INVASIONS) and (city not in TOMORROWS_CITIES_WITH_INVASIONS):
             response = f"{city} does not have any invasions today or tomorrow!"
     elif day == 'tomorrow': # tomorrow
-        if CITY_INFO[city]['invasion_tomorrow']:
+        if city in TOMORROWS_CITIES_WITH_INVASIONS:
             response = f"{city} has an invasion tomorrow at {CITY_INFO[city]['siege_time']} EST"
-        if not CITY_INFO[city]['invasion_tomorrow']:
+        else:
             response = f"{city} does not have an invasion tomorrow!"
     else: # assume today otherwise
         # if invasion later and it is not siege time yet
-        if CITY_INFO[city]['invasion_today'] and siege_window_in_future:
+        if (city in TODAYS_CITIES_WITH_INVASIONS) and siege_window_in_future:
             duration_str = await get_time_til_hour(CITY_INFO[city]['siege_time'])
             response = f"{city} has an invasion later today in {duration_str} at {CITY_INFO[city]['siege_time']} EST"
         # if invasion happened earlier today
-        if CITY_INFO[city]['invasion_today'] and not siege_window_in_future:
+        if (city in TODAYS_CITIES_WITH_INVASIONS) and not siege_window_in_future:
             response = f"{city} had an invasion earlier today at {CITY_INFO[city]['siege_time']} EST"
         # if no invasion today
-        if not CITY_INFO[city]['invasion_today']:
+        if city not in TODAYS_CITIES_WITH_INVASIONS:
             response = f"{city} does not have an invasion today!"
     return response
 
@@ -193,11 +239,10 @@ def refresh_invasion_data(city:str = None) -> None:
         )
         logger.debug(f'Response from db: {response}')
         if 'Item' in response:
-            CITY_INFO[c_name]['invasion_today'] = True
+            TODAYS_CITIES_WITH_INVASIONS.append(c_name)
+            logger.debug(f"Determined invasion happening today in {c_name}")
         else:
-            CITY_INFO[c_name]['invasion_today'] = False
-        CITY_INFO[c_name]['invasion_today_date'] = today_search_date
-        logger.debug(f"Determined today's invasion status: {CITY_INFO[c_name]['invasion_today']}")
+            logger.debug(f"Determined no invasion is happening today in {c_name}")
         # Get tomorrow's invasions
         logger.debug(f"Attempting to find tomorrow's invasions in table: {city_db_table}")
         tomorrow_search_date = str((datetime.date.today() + datetime.timedelta(days=1)).strftime('%Y-%m-%d'))
@@ -209,11 +254,10 @@ def refresh_invasion_data(city:str = None) -> None:
         )
         logger.debug(f'Response from db: {response}')
         if 'Item' in response:
-            CITY_INFO[c_name]['invasion_tomorrow'] = True
+            TOMORROWS_CITIES_WITH_INVASIONS.append(c_name)
+            logger.debug(f"Determined invasion happening tomorrow in {c_name}")
         else:
-            CITY_INFO[c_name]['invasion_tomorrow'] = False
-        CITY_INFO[c_name]['invasion_tomorrow_date'] = tomorrow_search_date
-        logger.debug(f"Determined tomorrow's invasion status: {CITY_INFO[c_name]['invasion_tomorrow']}")
+            logger.debug(f"Determined no invasion is happening tomorrow in {c_name}")
     logger.debug('Completed running refresh_invasion_data()')
 
 def refresh_siege_window(city:str = None) -> None:
@@ -237,6 +281,23 @@ def refresh_siege_window(city:str = None) -> None:
         CITY_INFO[city_name]['siege_time'] = response['Item']['time']['S']
         logger.debug(f"Determined siege time in {city_name}: {CITY_INFO[city_name]['siege_time']}")
     logger.debug('Completed running refresh_siege_window()')
+
+async def send_city_invasion_announcement(city):
+    '''Sends a city invasion announcement to [city] if the city has that enabled. See announcement_schedules.json'''
+    logger.debug(f'Attempting to send_city_invasion_announcement() for city: {city}')
+    if (city in CITIES_WITH_ANNOUNCE_ENABLED) and (city in TODAYS_CITIES_WITH_INVASIONS):
+        allowed_mentions = discord.AllowedMentions(everyone=True)
+        announcement_message = \
+            f"@everyone There is an invasion today in {city} at {CITY_INFO[city]['siege_time']}. " + \
+            'Please do not forget to sign up at the War Board in town. Remember to sign up early ' + \
+            'to help ensure you get a spot!'
+        announcement_channel_id = bot.get_channel(CITY_INFO[city]['announcement_channel_id'])
+        logger.debug(f"Sending announcement message for {city} to {str(CITY_INFO[city]['announcement_channel_id'])}")
+        await announcement_channel_id.send(announcement_message, allowed_mentions=allowed_mentions)
+    elif city not in CITIES_WITH_ANNOUNCE_ENABLED:
+        logger.debug(f'Could not find {city} in enabled city list: {CITIES_WITH_ANNOUNCE_ENABLED}')
+    else:
+        logger.debug(f'Determined {city} does not have an invasion today, no announcement needed.')
 
 city_slash_choice_list = []
 for city_choice_name in CITY_INFO:
@@ -275,8 +336,8 @@ day_slash_choice_list = [
                 )
             ])
 async def invasion(ctx, city: str, day: str = None):
-    '''Responds to !city [city] [day] command with the invasion status and siege window for [city] on [day]'''
-    logger.info(f'!city invoked for {city} on {day}')
+    '''Responds to /city [city] [day] command with the invasion status and siege window for [city] on [day]'''
+    logger.info(f'/city [city: {city}] [day: {day}] invoked')
     # if times are valid values
     if day is None or day == 'today' or day == 'tomorrow':
         response = await get_city_invasion_string(city, day)
@@ -294,33 +355,21 @@ async def invasion(ctx, city: str, day: str = None):
                     required=False,
                     choices=day_slash_choice_list
                 )
-            ]
-)
+            ])
 async def all_invasions(ctx, day: str = None):
-    '''Responds to !invasions command with all invasions happening today sorted by time'''
-    logger.info('!invasions invoked')
-    # refresh data if data came from a different day
-    today_invasions = {}
-    tomorrow_invasions = {}
-    for city in CITY_INFO:
-        if CITY_INFO[city]['invasion_today_date'] != datetime.date.today().strftime('%Y-%m-%d'):
-            await refresh_invasion_data()
-        if CITY_INFO[city]['invasion_today']:
-            logger.debug(f"Found invasion today in {city} at {CITY_INFO[city]['siege_time']}")
-            if await is_hour_in_future(CITY_INFO[city]['siege_time']):
-                today_invasions[city] = f"{CITY_INFO[city]['siege_time']}"
-            else:
-                logger.debug(f'Discarded invasion in {city} as it has already occurred.')
-        if CITY_INFO[city]['invasion_tomorrow']:
-            logger.debug(f"Found invasion tomorrow in {city} at {CITY_INFO[city]['siege_time']}")
-            tomorrow_invasions[city] = f"{CITY_INFO[city]['siege_time']}"
-    logger.debug(f'Total invasions found: {str(len(today_invasions.keys()) + len(tomorrow_invasions.keys()))}')
+    '''Responds to /invasions command with all invasions happening today sorted by time'''
+    logger.info(f'/invasions [day: {day}] invoked')
     if day == 'today' or day is None:
         # this sorts today's invasions returned by their time
-        sorted_partial = sorted(today_invasions, key = today_invasions.get)
         today_invasion_text = []
-        for key in sorted_partial:
-            today_invasion_text.append(f'{key} at {today_invasions[key]} EST')
+        if TODAYS_CITIES_WITH_INVASIONS: # if any invasions today
+            todays_cities_and_windows = {}
+            for today_city in TODAYS_CITIES_WITH_INVASIONS:
+                if await is_hour_in_future(CITY_INFO[today_city]['siege_time']):
+                    todays_cities_and_windows[today_city] = CITY_INFO[today_city]['siege_time']
+            sorted_partial = sorted(todays_cities_and_windows, key = todays_cities_and_windows.get)
+            for key in sorted_partial:
+                today_invasion_text.append(f"{key} at {CITY_INFO[key]['siege_time']}")
         # determine today's response
         if len(today_invasion_text) > 2:
             today_invasion_str = ', '.join(today_invasion_text)
@@ -333,17 +382,21 @@ async def all_invasions(ctx, day: str = None):
             today_response = 'There are no invasions happening today!'
     if day == 'tomorrow' or day is None:
         # this sorts tomorrow's invasions returned by their time
-        sorted_partial = sorted(tomorrow_invasions, key = tomorrow_invasions.get)
         tomorrow_invasion_text = []
-        for key in sorted_partial:
-            tomorrow_invasion_text.append(f'{key} at {tomorrow_invasions[key]} EST')
+        if TOMORROWS_CITIES_WITH_INVASIONS: # if any invasions tomorrow
+            tomorrows_cities_and_windows = {}
+            for tomorrow_city in TOMORROWS_CITIES_WITH_INVASIONS:
+                tomorrows_cities_and_windows[tomorrow_city] = CITY_INFO[tomorrow_city]['siege_time']
+            sorted_partial = sorted(tomorrows_cities_and_windows, key = tomorrows_cities_and_windows.get)
+            for key in sorted_partial:
+                tomorrow_invasion_text.append(f"{key} at {CITY_INFO[key]['siege_time']}")
         # determine tomorrow's response
         if len(tomorrow_invasion_text) > 2:
             tomorrow_invasion_str = ', '.join(tomorrow_invasion_text)
             tomorrow_response = f'Tomorrow there are {str(len(tomorrow_invasion_text))} invasions: {tomorrow_invasion_str}'
-        elif len(today_invasion_text) == 2:
+        elif len(tomorrow_invasion_text) == 2:
             tomorrow_response = f'Tomorrow there are 2 invasions: {tomorrow_invasion_text[0]} and {tomorrow_invasion_text[1]}'
-        elif len(today_invasion_text) == 1:
+        elif len(tomorrow_invasion_text) == 1:
             tomorrow_response = f'Tomorrow there is one invasion: {tomorrow_invasion_text[0]}'
         else:
             tomorrow_response = 'There are no invasions happening tomorrow!'
@@ -353,17 +406,14 @@ async def all_invasions(ctx, day: str = None):
         response = today_response
     elif day == 'tomorrow':
         response = tomorrow_response
-    else:
-        response = "Sorry, I didn't understand what day you wanted." \
-            + '\n' + 'Please use !invasions, !invasions today or !invasions tomorrow'
     await ctx.send(response)
 
 @slash.slash(name='windows',
             description='Responds with all siege windows in the server'
 )
 async def windows(ctx):
-    '''Respods to !windows command with a list of siege windows sorted alphabetically'''
-    logger.info('!windows invoked')
+    '''Respods to /windows command with a list of siege windows sorted alphabetically'''
+    logger.info('/windows invoked')
     window_texts = ['The server siege windows are:']
     cities = []
     for key in CITY_INFO:
@@ -375,13 +425,12 @@ async def windows(ctx):
     response = '\n'.join(t for t in window_texts)
     await ctx.send(response)
 
-@tasks.loop(hours = 2)
+@tasks.loop(hours = 1)
 async def info_gather():
-    '''Executes referesh_invasion_data and refresh_siege_window every two hours'''
+    '''Executes referesh_invasion_data and refresh_siege_window every hour'''
     logger.info('Attempting to run scheduled task info_gather()')
     refresh_invasion_data()
     refresh_siege_window()
     logger.info('Completed running scheduled task info_gather()')
 
-info_gather.start()
 bot.run(config['DISCORD_TOKEN'])

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -116,11 +116,13 @@ else:
 @bot.event
 async def on_ready():
     '''This function is activated when the bot reaches a 'ready' state.'''
-    logger.debug('Bot is ready')
+    logger.info('Bot is ready')
     if not DEV_MODE:
         try:
+            logger.debug('Attempting to start scheduler')
             scheduler = AsyncIOScheduler()
             for city in CITIES_WITH_ANNOUNCE_ENABLED:
+                logger.debug(f'Adding job to scheduler for announcements in {city}')
                 scheduler.add_job(
                     send_city_invasion_announcement,
                     trigger=CronTrigger(
@@ -129,6 +131,7 @@ async def on_ready():
                         second="0"),
                     args=[city]
                 )
+            logger.debug('Adding job to refresh invasion data daily at midnight')
             scheduler.add_job(
                 refresh_invasion_data,
                 trigger=CronTrigger(hour="0", minute="0", second="0")
@@ -427,7 +430,7 @@ async def windows(ctx):
 
 @tasks.loop(hours = 1)
 async def info_gather():
-    '''Executes referesh_invasion_data and refresh_siege_window every hour'''
+    '''Executes referesh_invasion_data and refresh_siege_window every hour or on command'''
     logger.info('Attempting to run scheduled task info_gather()')
     refresh_invasion_data()
     refresh_siege_window()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+apscheduler
 boto3
 discord.py
 discord-py-slash-command

--- a/scripts/set_permissions_and_install_deps
+++ b/scripts/set_permissions_and_install_deps
@@ -1,5 +1,6 @@
 #!/bin/bash
 sudo cp /opt/.invasion_bot_secrets /opt/invasion-bot/.env.secret
+sudo cp /opt/.invasion_bot_announcement_schedules.json /opt/invasion-bot/announcement_schedules.json
 sudo chown -R bot-user:bot-user /opt/invasion-bot
 sudo chmod +x /opt/invasion-bot/discord_bot.py
 cd /opt/invasion-bot


### PR DESCRIPTION
Added features:
- Announcements! The bot can announce to company/other interested channels the day of selected city invasions. Config is done in json and features customizable run times.

Behind the scenes:
- Added CI/CD task to copy the prod schedule file
- Added scheduled bot task to sync new data daily at midnight to ensure "today's" data is really today's
- Completed move to async functions
- Improvements to logging clarity and function docstrings
- Increased data refresh frequency from every 2 hours -> hourly
- Logic improvements and reductions in on-call logic to reduce response time